### PR TITLE
Removed deprecated reference

### DIFF
--- a/php/rj_get_highlighted_code.php
+++ b/php/rj_get_highlighted_code.php
@@ -55,7 +55,7 @@ $useClasses		= getPostedValue('useClasses');
 
 //===
 // initialize GeSHi
-$geshi =& new GeSHi($codeContent, $codeType);
+$geshi = new GeSHi($codeContent, $codeType);
 
 //===
 // Tell GeSHi to use stylesheets. Note that this should be the fist thing


### PR DESCRIPTION
Eliminated warning: "Deprecated: Assigning the return value of new by reference is deprecated" (PHP 5)

Tested on Moodle 2.9.1 with TinyMCE 3.5.11 and PHP 5.4.
